### PR TITLE
Create tests (and add missing path functionality) for user stories #9 and #10

### DIFF
--- a/helpers/databaseHelper.js
+++ b/helpers/databaseHelper.js
@@ -4,10 +4,14 @@ const database = require('knex')(configuration);
 
 async function getPlaylistFavorites(playlistId) {
   var favorites = await database('playlist_songs')
-  .innerJoin('favorite_songs', 'playlist_songs.song_id', 'favorite_songs.id')
-  .where('playlist_songs.playlist_id', playlistId)
-  .select("favorite_songs.id", "favorite_songs.title", "favorite_songs.artist_name as artistName", "favorite_songs.genre", "favorite_songs.rating");
-  return favorites
+    .innerJoin('favorite_songs', 'playlist_songs.song_id', 'favorite_songs.id')
+    .where('playlist_songs.playlist_id', playlistId)
+    .select("favorite_songs.id", "favorite_songs.title", "favorite_songs.artist_name as artistName", "favorite_songs.genre", "favorite_songs.rating");
+  if (favorites[0]) {
+    return favorites
+  } else {
+    return []
+  }
 }
 
 module.exports = {

--- a/helpers/formatHelper.js
+++ b/helpers/formatHelper.js
@@ -12,15 +12,28 @@ function formatSong(song) {
 }
 
 function formatPlaylist(playlist, favorites) {
-  return {
-    id: playlist[0].id,
-    title: playlist[0].title,
-    songCount: favorites.length,
-    songAvgRating: mathHelper.calculateAvgRating(favorites),
-    favorites: favorites,
-    createdAt: playlist[0].createdAt,
-    updatedAt: playlist[0].updatedAt
+  if (favorites.length > 0) {
+    var formattedPlaylist = {
+      id: playlist[0].id,
+      title: playlist[0].title,
+      songCount: favorites.length,
+      songAvgRating: mathHelper.calculateAvgRating(favorites),
+      favorites: favorites,
+      createdAt: playlist[0].createdAt,
+      updatedAt: playlist[0].updatedAt
+    }
+  } else {
+    var formattedPlaylist = {
+      id: playlist[0].id,
+      title: playlist[0].title,
+      songCount: 0,
+      songAvgRating: 0,
+      favorites: favorites,
+      createdAt: playlist[0].createdAt,
+      updatedAt: playlist[0].updatedAt
+    }
   }
+  return formattedPlaylist;
 }
 
 module.exports = {

--- a/tests/playlistSongs.spec.js
+++ b/tests/playlistSongs.spec.js
@@ -44,7 +44,6 @@ describe('Test creating playlist_songs', () => {
       const res = await request(app)
         .post(`/api/v1/playlists/${playlistId}/favorites/${favoriteId}`);
 
-      console.log(res)
       expect(res.statusCode).toBe(201);
 
       expect(res.body).toHaveProperty('success');

--- a/tests/playlistSongs.spec.js
+++ b/tests/playlistSongs.spec.js
@@ -1,0 +1,107 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test creating playlist_songs', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+    await database.raw('truncate table favorite_songs cascade');
+
+    const playlist = {
+      title: 'Test Playlist'
+    };
+
+    const favorite = {
+      title: 'I Will Not Bow',
+      artist_name: 'Breaking Benjamin',
+      genre: 'Rock',
+      rating: 68
+    };
+
+    await database('playlists').insert(playlist, 'id');
+    await database('favorite_songs').insert(favorite, 'id');
+  });
+
+  afterEach(() => {
+    database.raw('truncate table playlists cascade');
+    database.raw('truncate table favorite_songs cascade');
+  });
+
+  describe('test playlist_songs POST', () => {
+    it('can create a playlist_song', async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+
+      const favorite = await database('favorite_songs')
+        .where('title', 'I Will Not Bow').select('id');
+      const favoriteId = favorite[0].id;
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlistId}/favorites/${favoriteId}`);
+
+      console.log(res)
+      expect(res.statusCode).toBe(201);
+
+      expect(res.body).toHaveProperty('success');
+      expect(res.body.success).toBe("I Will Not Bow has been added to Test Playlist!");
+    });
+
+    it("can't create a playlist_song that's already been created", async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+
+      const favorite = await database('favorite_songs')
+        .where('title', 'I Will Not Bow').select('id');
+      const favoriteId = favorite[0].id;
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlistId}/favorites/${favoriteId}`);
+
+      const res2 = await request(app)
+        .post(`/api/v1/playlists/${playlistId}/favorites/${favoriteId}`);
+
+      expect(res2.statusCode).toBe(400);
+      expect(res2.body.message).toBe("I Will Not Bow is already in Test Playlist!")
+    })
+
+    it("can't create a playlist_song with a wrong playlist id", async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+      const wrongId = playlistId + 10;
+
+      const favorite = await database('favorite_songs')
+        .where('title', 'I Will Not Bow').select('id');
+      const favoriteId = favorite[0].id;
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${wrongId}/favorites/${favoriteId}`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toBe("No playlist found matching that ID. Try again!")
+    })
+
+    it("can't create a playlist_song with a wrong song id", async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+
+      const favorite = await database('favorite_songs')
+        .where('title', 'I Will Not Bow').select('id');
+      const favoriteId = favorite[0].id;
+      const wrongId = favoriteId + 10;
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlistId}/favorites/${wrongId}`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.error).toBe("No song found matching that ID. Try again!")
+    })
+  });
+})

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -9,6 +9,7 @@ const database = require('knex')(configuration);
 describe('Test the playlists path', () => {
   beforeEach(async () => {
     await database.raw('truncate table playlists cascade');
+    await database.raw('truncate table favorite_songs cascade');
 
     const playlist = {
       title: 'Test Playlist'
@@ -18,12 +19,29 @@ describe('Test the playlists path', () => {
       title: 'Other Test Playlist'
     };
 
+    const favoriteSong = {
+      title: 'I Will Not Bow',
+      artist_name: 'Breaking Benjamin',
+      genre: 'Rock',
+      rating: 68
+    };
+
+    const favoriteSong2 = {
+      title: 'In Loving Memory',
+      artist_name: 'Alter Bridge',
+      genre: 'Rock',
+      rating: 30
+    };
+
     await database('playlists').insert(playlist, 'id');
     await database('playlists').insert(playlist2, 'id');
+    await database('favorite_songs').insert(favoriteSong, 'id');
+    await database('favorite_songs').insert(favoriteSong2, 'id');
   });
 
   afterEach(() => {
     database.raw('truncate table playlists cascade');
+    database.raw('truncate table favorite_songs cascade');
   });
 
   describe('test playlist DELETE one by id', () => {
@@ -54,6 +72,113 @@ describe('Test the playlists path', () => {
 
   describe('test playlists GET all', () => {
     it('happy path', async () => {
+      const res = await request(app)
+        .get(`/api/v1/playlists`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.length).toBe(2);
+
+      expect(res.body[0]).toHaveProperty('id');
+      expect(res.body[1]).toHaveProperty('id');
+
+      expect(res.body[0]).toHaveProperty('title');
+      expect(res.body[0].title).toBe('Test Playlist');
+      expect(res.body[1].title).toBe('Other Test Playlist');
+
+      expect(res.body[0]).toHaveProperty('createdAt');
+      expect(res.body[1]).toHaveProperty('createdAt');
+
+      expect(res.body[0]).toHaveProperty('updatedAt');
+      expect(res.body[1]).toHaveProperty('updatedAt');
+    });
+  });
+
+  describe('test playlists GET one by id', () => {
+    it('happy path with favorites', async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+
+      const favorite = await database('favorite_songs')
+        .where('title', 'I Will Not Bow').select('id');
+      const favoriteId = favorite[0].id;
+
+      const favorite2 = await database('favorite_songs')
+        .where('title', 'In Loving Memory').select('id');
+      const favoriteId2 = favorite2[0].id;
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlistId}/favorites/${favoriteId}`);
+
+      const res2 = await request(app)
+        .post(`/api/v1/playlists/${playlistId}/favorites/${favoriteId2}`);
+
+      const res3 = await request(app)
+        .get(`/api/v1/playlists/${playlistId}/favorites`);
+
+      expect(res3.statusCode).toBe(200);
+
+      expect(res3.body).toHaveProperty('id');
+
+      expect(res3.body).toHaveProperty('title');
+      expect(res3.body.title).toBe('Test Playlist');
+
+      expect(res3.body).toHaveProperty('songCount');
+      expect(res3.body.songCount).toBe(2);
+
+      expect(res3.body).toHaveProperty('songAvgRating');
+      expect(res3.body.songAvgRating).toBe(49);
+
+      expect(res3.body).toHaveProperty('favorites')
+      expect(res3.body.favorites.length).toBe(2)
+
+      expect(res3.body.favorites[0]).toHaveProperty('title');
+      expect(res3.body.favorites[0].title).toBe('I Will Not Bow');
+
+      expect(res3.body.favorites[0]).toHaveProperty('artistName');
+      expect(res3.body.favorites[0].artistName).toBe('Breaking Benjamin');
+
+      expect(res3.body.favorites[0]).toHaveProperty('genre');
+      expect(res3.body.favorites[0].genre).toBe('Rock');
+
+      expect(res3.body.favorites[0]).toHaveProperty('rating');
+      expect(res3.body.favorites[0].rating).toBe(68);
+
+      expect(res3.body).toHaveProperty('createdAt');
+
+      expect(res3.body).toHaveProperty('updatedAt');
+    });
+
+    it('happy path with no favorites', async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+
+      const res = await request(app)
+        .get(`/api/v1/playlists/${playlistId}/favorites`);
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body).toHaveProperty('id');
+
+      expect(res.body).toHaveProperty('title');
+      expect(res.body.title).toBe('Test Playlist');
+
+      expect(res.body).toHaveProperty('songCount');
+      expect(res.body.songCount).toBe(0);
+
+      expect(res.body).toHaveProperty('songAvgRating');
+      expect(res.body.songAvgRating).toBe(0);
+
+      expect(res.body).toHaveProperty('favorites')
+      expect(res.body.favorites.length).toBe(0)
+
+      expect(res.body).toHaveProperty('createdAt');
+
+      expect(res.body).toHaveProperty('updatedAt');
+    });
+
+    it('sad path', async () => {
       const res = await request(app)
         .get(`/api/v1/playlists`);
 

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -179,24 +179,16 @@ describe('Test the playlists path', () => {
     });
 
     it('sad path', async () => {
+      const playlist = await database('playlists')
+        .where('title', 'Test Playlist').select('id');
+      const playlistId = playlist[0].id;
+      const wrongId = playlistId + 10;
+
       const res = await request(app)
-        .get(`/api/v1/playlists`);
+        .get(`/api/v1/playlists/${wrongId}/favorites`);
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body.length).toBe(2);
-
-      expect(res.body[0]).toHaveProperty('id');
-      expect(res.body[1]).toHaveProperty('id');
-
-      expect(res.body[0]).toHaveProperty('title');
-      expect(res.body[0].title).toBe('Test Playlist');
-      expect(res.body[1].title).toBe('Other Test Playlist');
-
-      expect(res.body[0]).toHaveProperty('createdAt');
-      expect(res.body[1]).toHaveProperty('createdAt');
-
-      expect(res.body[0]).toHaveProperty('updatedAt');
-      expect(res.body[1]).toHaveProperty('updatedAt');
+        expect(res.statusCode).toBe(404);
+        expect(res.body.error).toBe("No playlist found matching that ID. Try again!")
     });
   });
 


### PR DESCRIPTION
**Functionality**
- Add happy path for getting a playlist by id that has no favorites
- Add sad path for getting a playlist by id if the playlist id is wrong


**Testing**
- POST /api/v1/playlists/:id/favorites/:id
  - Happy path
  - Sad path: Wrong playlist id
  - Sad path: Wrong song id
  - Sad path: Song is already in playlist
- GET /api/v1/playlists/:id/favorites
  - Happy path: Playlist with favorites
  - Happy path: Playlist with no favorites
  - Sad path: Wrong playlist id